### PR TITLE
Better User objects in stack traces

### DIFF
--- a/slack-gamebot/models/user.rb
+++ b/slack-gamebot/models/user.rb
@@ -59,6 +59,10 @@ class User
     registered ? nickname || user_name : '<unregistered>'
   end
 
+  def inspect
+    "lemme check my notes here, uh... oh, #{display_name}"
+  end
+
   def self.slack_mention?(user_name)
     Regexp.last_match[1] if user_name =~ /^<@(.*)>$/
   end
@@ -206,7 +210,7 @@ class User
     update_attributes!(losing_streak: longest_losing_streak, winning_streak: longest_winning_streak, current_streak: current_streak_value, current_streak_is_win: current_streak_is_win_flag)
   end
 
-  def calculate_streak_with_win! 
+  def calculate_streak_with_win!
     if current_streak_is_win && (winning_streak <= current_streak)
       update_attributes!(current_streak: (current_streak+1), winning_streak: (current_streak+1))
     elsif current_streak_is_win


### PR DESCRIPTION
Hear me out. What if instead of this:
<img width="442" alt="screen shot 2018-11-05 at 1 18 48 pm" src="https://user-images.githubusercontent.com/7516653/48027396-88b96800-e0fd-11e8-9d16-f59041cf7e6d.png">

The error message read this, instead:
```
undefined method `calculate_streaks_with_loss!' for lemme check my notes here, uh... oh, clint.maples
Did you mean?  calculate_streak_with_loss!
              calculate_streak_with_win!
```
we can live in that bright future today.